### PR TITLE
Fix extractText command error message

### DIFF
--- a/api/agent/browserAgent.js
+++ b/api/agent/browserAgent.js
@@ -62,7 +62,7 @@ export async function runBrowserAutomation(commands) {
           executionSummary.successful++;
           console.log(`✅ Step ${stepNumber} completed: ${dynamicResult}`);
         } else {
-          const log = await executeCommand(activePage, cmd);
+          const log = await executeCommand(activePage, cmd, stepNumber);
           logs.push(log);
           
           // 성공한 명령어 기록
@@ -393,7 +393,7 @@ export function getBrowserStatus() {
   };
 }
 
-async function executeCommand(page, cmd) {
+async function executeCommand(page, cmd, stepNumber) {
   const { action, description } = cmd;
 
   switch (action) {
@@ -432,7 +432,7 @@ async function executeCommand(page, cmd) {
       return `✅ ${description || `Scrolled ${direction}`}`;
 
     case 'extractText':
-      if (!cmd.selector) throw new Error(`Command ${index}: 'extractText' requires 'selector' field`);
+      if (!cmd.selector) throw new Error(`Command ${stepNumber}: 'extractText' requires 'selector' field`);
       const extractedText = await page.textContent(cmd.selector);
       return `✅ ${description || `Extracted text from ${cmd.selector}: "${extractedText}"`}`;
 


### PR DESCRIPTION
## Summary
- prevent ReferenceError in `extractText` by passing step number to `executeCommand`
- include step number in missing selector error message

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689acd82df3483239d827b07c4218ede